### PR TITLE
Bumped the version to 2.2.3. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chashmap-serde"
-version = "0.1.1"
+version = "2.2.3"
 authors = ["ticki <Ticki@users.noreply.github.com>","cubicle-jockey <cubicle-jockey@users.noreply.github.com>"]
 description = "Fast, concurrent hash maps with extensive API and Serde support."
 repository = "https://github.com/cubicle-jockey/chashmap-serde.git"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 //! Concurrent hash maps.
 //!
+//! This is a clone of https://gitlab.redox-os.org/redox-os/chashmap, which at time of writing seems largely unmaintained.
+//! <b>I take no credit for the original author's hard work.</b> <i>My contributions are to add serde support and any other features
+//! that I may personally need.</i>
+//!
 //! This crate implements concurrent hash maps, based on bucket-level multi-reader locks. It has
 //! excellent performance characteristics¹ and supports resizing, in-place mutation and more.
 //!


### PR DESCRIPTION
Bumped the version to 2.2.3. 

The orginal chashmap is well tested (what chashmap-serde was cloned from), so there shouldn't be a reason to have started over at v0.1.0.